### PR TITLE
Pre-release v.1.1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+
+
+## [v1.1.0.0] - {waiting-for-modhub}
 - Added `l10n_uk.xml` by Gonimy-Vetrom
 - Fixed temperature misalignment for widesceen resolutions for [#3](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/3)
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)

--- a/FS25_ExtendedGameInfoDisplay/modDesc.xml
+++ b/FS25_ExtendedGameInfoDisplay/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
-<modDesc descVersion="92">
+<modDesc descVersion="94">
   <author>Peppie84</author>
-  <version>1.0.0.0</version>
+  <version>1.1.0.0</version>
   <title>
     <en>Extended Game Infodisplay</en>
     <de>Erweiterte Spiel-Infodarstellung</de>
@@ -10,10 +10,24 @@
     <en><![CDATA[
 Expands the current GameInfoDisplay in the upper right corner by displaying the current year under the date and a temperature feature with an indicator of whether the temperature is falling, staying constant or rising, the display of the current temperature. I also added the min/max temperature of the day.
 
+Changelog v1.1.0.0:
+- Moddesc update
+- Added translation for uk and tr
+- Fixed temperature misalignment for widesceen resolutions
+- Fixed next weather icon glitch
+- Fixed rounding for current temperature
+
 For more information, help and reporting issues please visit <a href='https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay'>GitHub</a>.
 ]]></en>
     <de><![CDATA[
 Erweitert die aktuelle GameInfoDisplay oben rechts um die Anzeige des aktuellen Jahres unter dem Datum und einem Temperaturfeature mit einem Indikator ob die Temepratur fällt, gleich bleibt oder steigt, die Anzeige der aktuellen Temperatur und der min/max Temperatur des Tages.
+
+Changelog v1.1.0.0:
+- Moddesc aktualisiert
+- Übersetzung für uk und tr hinzugefügt
+- Fehlerhafte Ausrichtung der Temperatur bei Widescreen-Auflösungen behoben
+- Glitch beim forecast Wetter behoben
+- Rundung bei der aktuellen Temperatur eingebaut
 
 Weitere Informationen, Hilfe und Probleme melden findest Du unter <a href='https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay'>GitHub</a>.
 ]]></de>

--- a/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
+++ b/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
@@ -47,14 +47,14 @@ end
 ---Overwrite GameInfoDisplay.draw()
 ---@param overwrittenFunc function
 function ExtendedGameInfoDisplay:gameinfodisplay__draw(overwrittenFunc)
+    local environment = g_currentMission.environment
+    local weatherType = environment.weather:getCurrentWeatherType()
+    local forcastDayTime = environment.dayTime + ExtendedGameInfoDisplay.WEATHER_HOURS_FORECAST
+    local forcastDay = environment.currentMonotonicDay
+    forcastDayTime, forcastDay = environment:getDayAndDayTime(forcastDayTime, forcastDay)
+    local nextWeatherType = environment.weather:getNextWeatherType(forcastDayTime, forcastDay)
+
     overwrittenFunc(self)
-
-    local weatherType = g_currentMission.environment.weather:getCurrentWeatherType()
-    local forcastDayTime = g_currentMission.environment.dayTime + ExtendedGameInfoDisplay.WEATHER_HOURS_FORECAST
-    local forcastDay = g_currentMission.environment.currentMonotonicDay
-    forcastDayTime, forcastDay = g_currentMission.environment:getDayAndDayTime(forcastDayTime, forcastDay)
-    local nextWeatherType = g_currentMission.environment.weather:getNextWeatherType(forcastDay, forcastDayTime)
-
 
     -- Strech the background and render new!
     self.infoBgScale.width = self:scalePixelToScreenWidth(ExtendedGameInfoDisplay.STRECH_GAME_INFO_DISPLAY)

--- a/FS25_ExtendedGameInfoDisplay/translations/l10n_uk.xml
+++ b/FS25_ExtendedGameInfoDisplay/translations/l10n_uk.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
-  <translationContributors>Gonimy_Vetrom</translationContributors>
+  <translationContributors>Gonimy_Vetrom, garik-59</translationContributors>
   <elements>
-    <e k="mod_title" v="Extended Game Infodisplay"/>
+    <e k="mod_title" v="Розширений інформаційний дисплей гри"/>
     <e k="yearinfo_current_year" v="Рік"/>
   </elements>
 </l10n>


### PR DESCRIPTION
**[v1.1.0.0]**

- Added `l10n_uk.xml` by Gonimy-Vetrom
- Fixed temperature misalignment for widesceen resolutions for [#3](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/3)
- Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
- Fixed next weather icon glitch for [#11](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/11)
- Fixed rounding problem for current temperature for [#10](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/10)

## Current release candidate (2025-01-24 21:55)
[FS25_ExtendedGameInfoDisplay.zip](https://github.com/user-attachments/files/18541772/FS25_ExtendedGameInfoDisplay.zip)

