### PR TITLE
Release v1.1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `l10n_uk.xml` by Gonimy-Vetrom
 - Fixed temperature misalignment for widesceen resolutions for [#3](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/3)
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
+- Fixed rounding problem for current temperature for [#10](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/10)
 
 ## [v1.0.0.0] - 2025-01-09
 - Ported from LS22 to LS25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 
-## [v1.1.0.0] - {waiting-for-modhub}
+## [v1.1.0.0] - 2025-02-22
 - Added `l10n_uk.xml` by Gonimy-Vetrom
 - Fixed temperature misalignment for widesceen resolutions for [#3](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/3)
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
-
-
+- Added `l10n_ru.xml` by Gonimy-Vetrom
+- Added `l10n_uk.xml` by Gonimy-Vetrom
+  
 ## [v1.0.0.0] - 2025-01-09
 - Ported from LS22 to LS25
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Added `l10n_uk.xml` by Gonimy-Vetrom
+- Fixed temperature misalignment for widesceen resolutions for [#3](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/3)
 
 ## [v1.0.0.0] - 2025-01-09
 - Ported from LS22 to LS25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 - Added `l10n_uk.xml` by Gonimy-Vetrom
+- Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
 
 ## [v1.0.0.0] - 2025-01-09
 - Ported from LS22 to LS25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
-- Added `l10n_ru.xml` by Gonimy-Vetrom
 - Added `l10n_uk.xml` by Gonimy-Vetrom
-  
+
 ## [v1.0.0.0] - 2025-01-09
 - Ported from LS22 to LS25
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed temperature misalignment for widesceen resolutions for [#3](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/3)
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
 - Fixed next weather icon glitch for [#11](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/11)
+- Fixed rounding problem for current temperature for [#10](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/10)
 
 ## [v1.0.0.0] - 2025-01-09
 - Ported from LS22 to LS25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+
+
+## [v1.1.0.0] - {waiting-for-modhub}
 - Added `l10n_uk.xml` by Gonimy-Vetrom
 - Fixed temperature misalignment for widesceen resolutions for [#3](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/3)
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `l10n_uk.xml` by Gonimy-Vetrom
 - Fixed temperature misalignment for widesceen resolutions for [#3](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/3)
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
+- Fixed next weather icon glitch for [#11](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/11)
 
 ## [v1.0.0.0] - 2025-01-09
 - Ported from LS22 to LS25

--- a/FS25_ExtendedGameInfoDisplay/modDesc.xml
+++ b/FS25_ExtendedGameInfoDisplay/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
-<modDesc descVersion="92">
+<modDesc descVersion="94">
   <author>Peppie84</author>
-  <version>1.0.0.0</version>
+  <version>1.1.0.0</version>
   <title>
     <en>Extended Game Infodisplay</en>
     <de>Erweiterte Spiel-Infodarstellung</de>
@@ -10,10 +10,24 @@
     <en><![CDATA[
 Expands the current GameInfoDisplay in the upper right corner by displaying the current year under the date and a temperature feature with an indicator of whether the temperature is falling, staying constant or rising, the display of the current temperature. I also added the min/max temperature of the day.
 
+Changelog v1.1.0.0:
+- Moddesc update
+- Added translation for uk and tr
+- Fixed temperature misalignment for widesceen resolutions
+- Fixed next weather icon glitch
+- Fixed rounding for current temperature
+
 For more information, help and reporting issues please visit <a href='https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay'>GitHub</a>.
 ]]></en>
     <de><![CDATA[
 Erweitert die aktuelle GameInfoDisplay oben rechts um die Anzeige des aktuellen Jahres unter dem Datum und einem Temperaturfeature mit einem Indikator ob die Temepratur fällt, gleich bleibt oder steigt, die Anzeige der aktuellen Temperatur und der min/max Temperatur des Tages.
+
+Changelog v1.1.0.0:
+- Moddesc aktualisiert
+- Übersetzung für uk und tr hinzugefügt
+- Fehlerhafte Ausrichtung der Temperatur bei Widescreen-Auflösungen behoben
+- Glitch beim forecast Wetter behoben
+- Rundung bei der aktuellen Temperatur eingebaut
 
 Weitere Informationen, Hilfe und Probleme melden findest Du unter <a href='https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay'>GitHub</a>.
 ]]></de>

--- a/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
+++ b/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
@@ -76,7 +76,7 @@ function ExtendedGameInfoDisplay:gameinfodisplay__draw(overwrittenFunc)
 end
 
 function ExtendedGameInfoDisplay:setTemperaturePosition(gameInfoDisplay)
-    local referencePositionX =  gameInfoDisplay.calendarIcon.x - gameInfoDisplay:scalePixelToScreenHeight(65)
+    local referencePositionX =  gameInfoDisplay.calendarIcon.x - gameInfoDisplay:scalePixelToScreenWidth(120)
     gameInfoDisplay.temperature.x = referencePositionX
     gameInfoDisplay.temperatureUp.x = referencePositionX
     gameInfoDisplay.temperatureDown.x = referencePositionX

--- a/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
+++ b/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
@@ -74,7 +74,7 @@ function ExtendedGameInfoDisplay:gameinfodisplay__draw(overwrittenFunc)
 end
 
 function ExtendedGameInfoDisplay:setTemperaturePosition(gameInfoDisplay)
-    local referencePositionX =  gameInfoDisplay.calendarIcon.x - gameInfoDisplay:scalePixelToScreenWidth(120)
+    local referencePositionX =  gameInfoDisplay.calendarIcon.x - gameInfoDisplay:scalePixelToScreenWidth(115)
     gameInfoDisplay.temperature.x = referencePositionX
     gameInfoDisplay.temperatureUp.x = referencePositionX
     gameInfoDisplay.temperatureDown.x = referencePositionX
@@ -91,20 +91,20 @@ function ExtendedGameInfoDisplay:setTemperatureTrendAndDraw(gameInfoDisplay)
     gameInfoDisplay.temperatureUp:draw()
     gameInfoDisplay.temperatureDown:draw()
 
-    local seperatorPosX = gameInfoDisplay.temperature.x - gameInfoDisplay:scalePixelToScreenWidth(5)
+    local seperatorPosX = gameInfoDisplay.temperature.x - gameInfoDisplay:scalePixelToScreenWidth(10)
     local seperatorPosYStart = gameInfoDisplay.temperature.y + gameInfoDisplay:scalePixelToScreenHeight(ExtendedGameInfoDisplay.TEMPERATURE_ICON_SIZE-1)
     local seperatorPosYEnd = gameInfoDisplay.temperature.y + gameInfoDisplay:scalePixelToScreenHeight(4)
 
-    drawLine2D(seperatorPosX, seperatorPosYStart, seperatorPosX, seperatorPosYEnd, gameInfoDisplay.separatorWidth, 1,1,1,0.2)
+    drawLine2D(seperatorPosX, seperatorPosYStart, seperatorPosX, seperatorPosYEnd, gameInfoDisplay.separatorWidth, 1,1,1, 0.2)
 end
 
 function ExtendedGameInfoDisplay:drawTemperatureText(gameInfoDisplay)
     local minTemperatureInC, maxTemperatureInC = g_currentMission.environment.weather:getCurrentMinMaxTemperatures()
-    local currentTemperatureInC = g_currentMission.environment.weather:getCurrentTemperature()
+    local currentTemperatureInC = g_currentMission.environment.weather.forecast:getCurrentWeather()
 
-    local minTemperatureExpanded =  g_i18n:getTemperature(minTemperatureInC)
-    local maxTemperatureExpanded = g_i18n:getTemperature(maxTemperatureInC)
-    local currentTemperatureExpanded = g_i18n:getTemperature(currentTemperatureInC)
+    local minTemperatureExpanded =  MathUtil.round(g_i18n:getTemperature(minTemperatureInC), 0)
+    local maxTemperatureExpanded = MathUtil.round(g_i18n:getTemperature(maxTemperatureInC), 0)
+    local currentTemperatureExpanded = MathUtil.round(g_i18n:getTemperature(currentTemperatureInC.temperature), 0)
 
     local scaledTextSizeForCurrentTemperature = gameInfoDisplay:scalePixelToScreenHeight(19)
     local scaledTextSizeForTemperature = gameInfoDisplay:scalePixelToScreenHeight(14)
@@ -123,7 +123,7 @@ function ExtendedGameInfoDisplay:drawYearText(gameInfoDisplay)
     local monthTextSize = gameInfoDisplay:scalePixelToScreenHeight(10)
     local scaledTextSizeForYear = gameInfoDisplay:scalePixelToScreenHeight(12)
 
-    local gameInfoDisplayPosX, gameInfoDisplayPosY = gameInfoDisplay:getPosition()
+    local _, gameInfoDisplayPosY = gameInfoDisplay:getPosition()
     local posX = gameInfoDisplay.calendarIcon.x + gameInfoDisplay.calendarIcon.width + gameInfoDisplay:scalePixelToScreenWidth(2)
     local posY = gameInfoDisplayPosY - gameInfoDisplay.calendarTextOffsetY - monthTextSize
 

--- a/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
+++ b/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
@@ -50,14 +50,11 @@ function ExtendedGameInfoDisplay:gameinfodisplay__draw(overwrittenFunc)
     overwrittenFunc(self)
 
     local weatherType = g_currentMission.environment.weather:getCurrentWeatherType()
-    local forcastDayTime = math.floor(g_currentMission.environment.dayTime + ExtendedGameInfoDisplay.WEATHER_HOURS_FORECAST )
-    local forcastDay = g_currentMission.environment.currentDay
-    if forcastDayTime > ExtendedGameInfoDisplay.HOURS_A_DAY then
-        forcastDayTime = forcastDayTime - ExtendedGameInfoDisplay.HOURS_A_DAY
-        forcastDay = forcastDay + 1
-    end
+    local forcastDayTime = g_currentMission.environment.dayTime + ExtendedGameInfoDisplay.WEATHER_HOURS_FORECAST
+    local forcastDay = g_currentMission.environment.currentMonotonicDay
+    forcastDayTime, forcastDay = g_currentMission.environment:getDayAndDayTime(forcastDayTime, forcastDay)
+    local nextWeatherType = g_currentMission.environment.weather:getNextWeatherType(forcastDay, forcastDayTime)
 
-    local nextWeatherType = g_currentMission.environment.weather:getNextWeatherType(forcastDay, forcastDayTime )
 
     -- Strech the background and render new!
     self.infoBgScale.width = self:scalePixelToScreenWidth(ExtendedGameInfoDisplay.STRECH_GAME_INFO_DISPLAY)
@@ -65,9 +62,10 @@ function ExtendedGameInfoDisplay:gameinfodisplay__draw(overwrittenFunc)
     self.infoBgScale:render()
 
     -- ReRender to bring it back to top
+    if weatherType ~= nextWeatherType then
+        self.weatherNextIcon:render()
+    end
     self.weatherIcon:render()
-    self.weatherNextIcon:render()
-    self.weatherNextIcon:setVisible(weatherType ~= nextWeatherType)
 
     ExtendedGameInfoDisplay:setTemperaturePosition(self)
     ExtendedGameInfoDisplay:setTemperatureTrendAndDraw(self)
@@ -139,7 +137,6 @@ end
 
 --- Initialize the mod
 local function init()
-    --HUD.new = Utils.prependedFunction(HUD.new, newHud)
     HUD.createDisplayComponents = Utils.overwrittenFunction(HUD.createDisplayComponents, ExtendedGameInfoDisplay.hud__createDisplayComponents)
     GameInfoDisplay.draw = Utils.overwrittenFunction(GameInfoDisplay.draw, ExtendedGameInfoDisplay.gameinfodisplay__draw)
 end

--- a/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
+++ b/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
@@ -76,7 +76,7 @@ function ExtendedGameInfoDisplay:gameinfodisplay__draw(overwrittenFunc)
 end
 
 function ExtendedGameInfoDisplay:setTemperaturePosition(gameInfoDisplay)
-    local referencePositionX =  gameInfoDisplay.calendarIcon.x - gameInfoDisplay:scalePixelToScreenWidth(120)
+    local referencePositionX =  gameInfoDisplay.calendarIcon.x - gameInfoDisplay:scalePixelToScreenWidth(115)
     gameInfoDisplay.temperature.x = referencePositionX
     gameInfoDisplay.temperatureUp.x = referencePositionX
     gameInfoDisplay.temperatureDown.x = referencePositionX
@@ -93,20 +93,20 @@ function ExtendedGameInfoDisplay:setTemperatureTrendAndDraw(gameInfoDisplay)
     gameInfoDisplay.temperatureUp:draw()
     gameInfoDisplay.temperatureDown:draw()
 
-    local seperatorPosX = gameInfoDisplay.temperature.x - gameInfoDisplay:scalePixelToScreenWidth(5)
+    local seperatorPosX = gameInfoDisplay.temperature.x - gameInfoDisplay:scalePixelToScreenWidth(10)
     local seperatorPosYStart = gameInfoDisplay.temperature.y + gameInfoDisplay:scalePixelToScreenHeight(ExtendedGameInfoDisplay.TEMPERATURE_ICON_SIZE-1)
     local seperatorPosYEnd = gameInfoDisplay.temperature.y + gameInfoDisplay:scalePixelToScreenHeight(4)
 
-    drawLine2D(seperatorPosX, seperatorPosYStart, seperatorPosX, seperatorPosYEnd, gameInfoDisplay.separatorWidth, 1,1,1,0.2)
+    drawLine2D(seperatorPosX, seperatorPosYStart, seperatorPosX, seperatorPosYEnd, gameInfoDisplay.separatorWidth, 1,1,1, 0.2)
 end
 
 function ExtendedGameInfoDisplay:drawTemperatureText(gameInfoDisplay)
     local minTemperatureInC, maxTemperatureInC = g_currentMission.environment.weather:getCurrentMinMaxTemperatures()
-    local currentTemperatureInC = g_currentMission.environment.weather:getCurrentTemperature()
+    local currentTemperatureInC = g_currentMission.environment.weather.forecast:getCurrentWeather()
 
-    local minTemperatureExpanded =  g_i18n:getTemperature(minTemperatureInC)
-    local maxTemperatureExpanded = g_i18n:getTemperature(maxTemperatureInC)
-    local currentTemperatureExpanded = g_i18n:getTemperature(currentTemperatureInC)
+    local minTemperatureExpanded =  MathUtil.round(g_i18n:getTemperature(minTemperatureInC), 0)
+    local maxTemperatureExpanded = MathUtil.round(g_i18n:getTemperature(maxTemperatureInC), 0)
+    local currentTemperatureExpanded = MathUtil.round(g_i18n:getTemperature(currentTemperatureInC.temperature), 0)
 
     local scaledTextSizeForCurrentTemperature = gameInfoDisplay:scalePixelToScreenHeight(19)
     local scaledTextSizeForTemperature = gameInfoDisplay:scalePixelToScreenHeight(14)
@@ -125,7 +125,7 @@ function ExtendedGameInfoDisplay:drawYearText(gameInfoDisplay)
     local monthTextSize = gameInfoDisplay:scalePixelToScreenHeight(10)
     local scaledTextSizeForYear = gameInfoDisplay:scalePixelToScreenHeight(12)
 
-    local gameInfoDisplayPosX, gameInfoDisplayPosY = gameInfoDisplay:getPosition()
+    local _, gameInfoDisplayPosY = gameInfoDisplay:getPosition()
     local posX = gameInfoDisplay.calendarIcon.x + gameInfoDisplay.calendarIcon.width + gameInfoDisplay:scalePixelToScreenWidth(2)
     local posY = gameInfoDisplayPosY - gameInfoDisplay.calendarTextOffsetY - monthTextSize
 
@@ -139,7 +139,6 @@ end
 
 --- Initialize the mod
 local function init()
-    --HUD.new = Utils.prependedFunction(HUD.new, newHud)
     HUD.createDisplayComponents = Utils.overwrittenFunction(HUD.createDisplayComponents, ExtendedGameInfoDisplay.hud__createDisplayComponents)
     GameInfoDisplay.draw = Utils.overwrittenFunction(GameInfoDisplay.draw, ExtendedGameInfoDisplay.gameinfodisplay__draw)
 end

--- a/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
+++ b/FS25_ExtendedGameInfoDisplay/src/extendedgameinfodisplay.lua
@@ -47,14 +47,14 @@ end
 ---Overwrite GameInfoDisplay.draw()
 ---@param overwrittenFunc function
 function ExtendedGameInfoDisplay:gameinfodisplay__draw(overwrittenFunc)
+    local environment = g_currentMission.environment
+    local weatherType = environment.weather:getCurrentWeatherType()
+    local forcastDayTime = environment.dayTime + ExtendedGameInfoDisplay.WEATHER_HOURS_FORECAST
+    local forcastDay = environment.currentMonotonicDay
+    forcastDayTime, forcastDay = environment:getDayAndDayTime(forcastDayTime, forcastDay)
+    local nextWeatherType = environment.weather:getNextWeatherType(forcastDayTime, forcastDay)
+
     overwrittenFunc(self)
-
-    local weatherType = g_currentMission.environment.weather:getCurrentWeatherType()
-    local forcastDayTime = g_currentMission.environment.dayTime + ExtendedGameInfoDisplay.WEATHER_HOURS_FORECAST
-    local forcastDay = g_currentMission.environment.currentMonotonicDay
-    forcastDayTime, forcastDay = g_currentMission.environment:getDayAndDayTime(forcastDayTime, forcastDay)
-    local nextWeatherType = g_currentMission.environment.weather:getNextWeatherType(forcastDay, forcastDayTime)
-
 
     -- Strech the background and render new!
     self.infoBgScale.width = self:scalePixelToScreenWidth(ExtendedGameInfoDisplay.STRECH_GAME_INFO_DISPLAY)

--- a/FS25_ExtendedGameInfoDisplay/translations/l10n_tr.xml
+++ b/FS25_ExtendedGameInfoDisplay/translations/l10n_tr.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<l10n>
+  <translationContributors>RuyaSavascisi</translationContributors>
+  <elements>
+    <e k="mod_title" v="Genişletilmiş Oyun Bilgi Ekranı"/>
+    <e k="yearinfo_current_year" v="Yıl"/>
+  </elements>
+</l10n>

--- a/FS25_ExtendedGameInfoDisplay/translations/l10n_uk.xml
+++ b/FS25_ExtendedGameInfoDisplay/translations/l10n_uk.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
-  <translationContributors>Gonimy_Vetrom</translationContributors>
+  <translationContributors>Gonimy_Vetrom, garik-59</translationContributors>
   <elements>
-    <e k="mod_title" v="Extended Game Infodisplay"/>
+    <e k="mod_title" v="Розширений інформаційний дисплей гри"/>
     <e k="yearinfo_current_year" v="Рік"/>
   </elements>
 </l10n>

--- a/FS25_ExtendedGameInfoDisplay/translations/l10n_uk.xml
+++ b/FS25_ExtendedGameInfoDisplay/translations/l10n_uk.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<l10n>
+  <translationContributors>Gonimy_Vetrom</translationContributors>
+  <elements>
+    <e k="mod_title" v="Extended Game Infodisplay"/>
+    <e k="yearinfo_current_year" v="Рік"/>
+  </elements>
+</l10n>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![FarmingSimulator-25](https://img.shields.io/badge/FarmingSimulator-25-73A302?style=flat-square)](https://www.farming-simulator.com/mods.php?title=fs2025)
 [![Last commit](https://img.shields.io/github/last-commit/Peppie84/FS25_ExtendedGameInfoDisplay?style=flat-square&color=important)](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/commits/development)
-[![Modhub Version](https://img.shields.io/badge/Modhub-v1.0.0.0-green?style=flat-square)](https://www.farming-simulator.com/mod.php?mod_id=306015&title=fs2025)
+[![Modhub Version](https://img.shields.io/badge/Modhub-v1.1.0.0-green?style=flat-square)](https://www.farming-simulator.com/mod.php?mod_id=306015&title=fs2025)
 [![GitHub issues](https://img.shields.io/github/issues/Peppie84/FS25_ExtendedGameInfoDisplay?style=flat-square)](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue?style=flat-square)](https://www.gnu.org/licenses/gpl-3.0)
 [![Top language](https://img.shields.io/github/languages/top/Peppie84/FS25_ExtendedGameInfoDisplay?style=flat-square&color=blueviolet)](https://github.com/search?q=repo%3APeppie84%FS25_ExtendedGameInfoDisplay++language%3ALua&type=code)


### PR DESCRIPTION
 **[v1.1.0.0] - 2025-02-22**
- Added `l10n_uk.xml` by Gonimy-Vetrom
- Fixed temperature misalignment for widesceen resolutions for [#3](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/3)
- Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
- Fixed next weather icon glitch for [#11](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/11)
- Fixed rounding problem for current temperature for [#10](https://github.com/Peppie84/FS25_ExtendedGameInfoDisplay/issues/10)